### PR TITLE
Minor Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
 CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
 
-if ((${CMAKE_SYSTEM_NAME} MATCHES "Dariwn") OR (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
+if ((${CMAKE_SYSTEM_NAME} MATCHES "Darwin") OR (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
   if(NOT (COMPILER_SUPPORTS_CXX11 OR COMPILER_SUPPORTS_CXX0X))
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
   endif()

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ### Generic Synthesis C++ Library
 
 
-1. About
-========================================
+# 1. About 
+
 Gamma is a cross-platform, C++ library for doing generic synthesis and 
 filtering of signals. It contains helpful mathematical functions, 
 types, such as vectors and complex numbers, an assortment of sequence 
@@ -12,26 +12,29 @@ It is oriented towards real-time sound and graphics synthesis, but is
 equally useful for non-real-time tasks.
 
 
-2. Compilation Instructions
-========================================
+# 2. Compilation Instructions 
+
 The source code can either be built into a library or directly compiled from source into an application.
 In the following, the base directory is where this README file is located.
 
 
-2.1 Building a Library
-----------------------------------------
+## 2.1 Building a Library
 
 Gamma uses Cmake to build. You should be able to build Gamma by running
 
+```Bash
 	cmake .
 	make
+```
 
 will build the library and the examples with automatically detected platform settings.
 You will need to install dependencies detailed in section 2.3 below.
 
 On OS X an Xcode project can be produced by running Cmake like this:
 
-        cmake  .
+```Bash
+    cmake  .
+```
 
 (You may need to delete old CMakeCache.txt and the CMakeFiles directory manually or using the distclean script, see below.)
 
@@ -45,23 +48,26 @@ Some useful options to pass to cmake include:
 To generate an Xcode project where you can try out the Gamma examples,
 you should run cmake like this:
 
-        cmake . -DBUILD_EXAMPLES=1 -G Xcode
+```Bash
+    cmake . -DBUILD_EXAMPLES=1 -G Xcode
+```
+	
+## 2.2 Compiling Direct From Source
 
-2.2 Compiling Direct From Source
----
 Individual Gamma files can easily be added and compiled directly from source into an existing project.
 This way there is no need to build Gamma before using, but it may require
 adding to your project a set of files as some Gamma files depend on others.
 
 Make sure to pass in the following flags to the compiler:
 
+```Bash
 	-D__STDC_CONSTANT_MACROS
 	-finline-functions (or -O3)
 	-fpeel-loops
+```
 
+## 2.3 Dependencies
 
-2.3 Dependencies
-----------------------------------------
 Gamma depends on PortAudio v19 and libsndfile for performing audio and sound file i/o, respectively.
 They are required only if using certain Gamma classes.
 PortAudio is required ONLY if you are using AudioIO (AudioIO.h).
@@ -71,28 +77,32 @@ You will also need Cmake to build Gamma.
 
 You can get these through standard package managers on Linux, or through MacPorts or HomeBrew on OS X.
 
-2.4 Build issues
----
+## 2.4 Build issues
 
 If you are having build issues (e.g. you want to use a Makefile but have used the Xcode generator, and cmake is giving you grief), running the `distclean` script will remove all Cmake cache and temporary files:
 
+```Bash
 	./distclean
-	
-3. Easy building and running
-===
+```	
+
+# 3. Easy building and running
 
 The simplest way to run Gamma applications is using the included run script like this:
 
-        ./run.sh path/to/source.cpp
-
+```Bash
+    ./run.sh path/to/source.cpp
+```
+	
 You can also build all the cpp files in a particular directory into a single application passing a directory name:
 
-        ./run.sh path/to/dir
+```Bash
+    ./run.sh path/to/dir
+```
 
 Running this script will build Gamma and the application, and will run it.
 
-4. Using the template
-===
+# 4. Using the template
+
 To build larger Gamma applications:
 
 1. Copy and rename the template/ directory

--- a/distclean
+++ b/distclean
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-rm -rf build/ CMakeCache.txt CMakeFiles/ cmake_install.cmake Makefile build.ninja rules.ninja Gamma.xcodeproj Gamma.build CMakeScripts
+rm -rf build/ CMakeCache.txt CMakeFiles/ cmake_install.cmake Makefile build.ninja rules.ninja Gamma.xcodeproj Gamma.build CMakeScripts CTestTestfile.cmake cmake_log.txt
 rm -rf AlloSystem-build/
 rm -rf doc/html/
 

--- a/distclean
+++ b/distclean
@@ -3,4 +3,4 @@
 rm -rf build/ CMakeCache.txt CMakeFiles/ cmake_install.cmake Makefile build.ninja rules.ninja Gamma.xcodeproj Gamma.build CMakeScripts CTestTestfile.cmake cmake_log.txt
 rm -rf AlloSystem-build/
 rm -rf doc/html/
-
+find . \( -name \*.filters -or -name \*.vcxproj -or -name \*.sln \) -delete

--- a/run.sh
+++ b/run.sh
@@ -64,7 +64,7 @@ fi
 shift
 
 if [ "$MSYSTEM" = "MINGW64" -o "$MSYSTEM" = "MINGW32" ]; then
-  GENERATOR_FLAG = "-GMSYS Makefiles"
+  GENERATOR_FLAG="-GMSYS Makefiles"
 fi
 
 if [ -n "$debugger" ]; then

--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,10 @@ done
 
 # Get the number of processors on OS X, linux, and (to-do) Windows.
 NPROC=$(grep --count ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu || 2)
+# Get it when on MinGW (Windows)
+if [ "$MSYSTEM" = "MINGW64" -o "$MSYSTEM" = "MINGW32" ]; then
+	NPROC=$NUMBER_OF_PROCESSORS
+fi
 # Save one core for the gui.
 PROC_FLAG=$((NPROC - 1))
 
@@ -59,10 +63,14 @@ fi
 # Don't pass target as Make flag.
 shift
 
+if [ "$MSYSTEM" = "MINGW64" -o "$MSYSTEM" = "MINGW32" ]; then
+  GENERATOR_FLAG = "-GMSYS Makefiles"
+fi
+
 if [ -n "$debugger" ]; then
-  cmake . "$TARGET_FLAG" "$DBUILD_FLAG" -DRUN_IN_DEBUGGER=1 "-DGAMMA_DEBUGGER=${debugger}" -DCMAKE_BUILD_TYPE=Debug > cmake_log.txt
+  cmake . "$GENERATOR_FLAG" "$TARGET_FLAG" "$DBUILD_FLAG" -DRUN_IN_DEBUGGER=1 "-DGAMMA_DEBUGGER=${debugger}" -DCMAKE_BUILD_TYPE=Debug > cmake_log.txt
 else
-  cmake . "$TARGET_FLAG" "$DBUILD_FLAG" -DRUN_IN_DEBUGGER=0 -DCMAKE_BUILD_TYPE=Release -Wno-dev > cmake_log.txt
+  cmake . "$GENERATOR_FLAG" "$TARGET_FLAG" "$DBUILD_FLAG" -DRUN_IN_DEBUGGER=0 -DCMAKE_BUILD_TYPE=Release -Wno-dev > cmake_log.txt
 fi
 
 make $TARGET -j$PROC_FLAG $*


### PR DESCRIPTION
- Upgraded a couple of old markdown lines at `README.md` 
- `distclean` now cleans Visual Studio project files as well 
- `run.sh` works on `MSYS` (got from [here](https://github.com/AlloSphere-Research-Group/AlloSystem/blob/devel/run.sh#L83) ) and gets the number of preprocessors from system environments on `MinGW32` or `MinGW64`
- Corrected typo: `Dariwn` to `Darwin` in `CMakeLists.txt`