### PR TITLE
virtual keyword added to Domain1::onDomainChange

### DIFF
--- a/Gamma/Domain.h
+++ b/Gamma/Domain.h
@@ -27,7 +27,7 @@ public:
 
 	/// Any instance state that depends on the samples/unit ratio should be 
 	/// updated here. The ratio of the new to the old samples/unit is passed in.
-	void onDomainChange(double /*ratioSPU*/){}
+	virtual void onDomainChange(double /*ratioSPU*/){}
 
 	void spu(double /*val*/){}			///< Set samples/unit
 	void ups(double /*val*/){}			///< Set units/sample


### PR DESCRIPTION
When I tried to use gam::ReverbMS<>, it caused a compile error below:

```
/src/allolib_playground/allolib/external/Gamma/Gamma/Delay.h:95:32: error: only virtual member functions can be marked 'override'
        void onDomainChange(double r) override;
                                      ^~~~~~~~
/src/allolib_playground/allolib/external/Gamma/Gamma/Spatial.h:130:21: note: in instantiation of template class
      'gam::Delay<float, Trunc, gam::Domain1>' requested here
class Echo : public Delay<Tv,Si,Td> {
                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/vector:427:68: note: in instantiation of template
      class 'gam::Echo<float, Trunc, Loop1P, gam::Domain1>' requested here
        __alloc_traits::destroy(__alloc(), _VSTD::__to_raw_pointer(--__soon_to_be_end));
                                                                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/vector:370:29: note: in instantiation of member
      function 'std::__1::__vector_base<gam::Echo<float, Trunc, Loop1P, gam::Domain1>, std::__1::allocator<gam::Echo<float, Trunc, Loop1P, gam::Domain1> >
      >::__destruct_at_end' requested here
    void clear() _NOEXCEPT {__destruct_at_end(__begin_);}
                            ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/vector:464:9: note: in instantiation of member
      function 'std::__1::__vector_base<gam::Echo<float, Trunc, Loop1P, gam::Domain1>, std::__1::allocator<gam::Echo<float, Trunc, Loop1P, gam::Domain1> >
      >::clear' requested here
        clear();
        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/vector:496:5: note: in instantiation of member
      function 'std::__1::__vector_base<gam::Echo<float, Trunc, Loop1P, gam::Domain1>, std::__1::allocator<gam::Echo<float, Trunc, Loop1P, gam::Domain1> >
      >::~__vector_base' requested here
    vector() _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
    ^
/Users/sihwapark/Documents/src/allolib_playground/allolib/external/Gamma/Gamma/Spatial.h:249:2: note: in instantiation of member function
      'std::__1::vector<gam::Echo<float, Trunc, Loop1P, gam::Domain1>, std::__1::allocator<gam::Echo<float, Trunc, Loop1P, gam::Domain1> > >::vector'
      requested here
        ReverbMS();
```

It is because that `ReverbMS` has a vector of `Echo<Tv, Si, LoopFilter, Domain1>` which is inherited from `Delay` and `Delay` is also inherited from a template type `Td` which can be either `DomainObserver` or `Domain1`, but only `onDomainChange(double)` in `DomainObserver` is virtual. 

So I changed `void Domain1::onDomainChange(double)` as a virtual function.

