### PR TITLE
pc - fix compiler warning about unused variable

### DIFF
--- a/Gamma/rnd.h
+++ b/Gamma/rnd.h
@@ -302,7 +302,7 @@ template <class T> inline T & cond(T& v, const T& va, const T& vb, float pab, fl
 
 template <class RNG>
 float gaussian(RNG& rng = rnd::gen){
-	float x1, x2, w, y1, y2;
+	float x1, x2, w, y1;
 
 	do{
 		x1 = uniS_float(rng);
@@ -312,7 +312,6 @@ float gaussian(RNG& rng = rnd::gen){
 
 	w = sqrt((-2.f * log(w)) / w);
 	y1 = x1 * w;
-	y2 = x2 * w;
 	return y1;
 }
 


### PR DESCRIPTION
When compiling programs that depend on Gamma, the following warning frequently pops up:

```
.../Gamma/rnd.h:305:23: warning: variable 'y2' set but not used [-Wunused-but-set-variable]
        float x1, x2, w, y1, y2;
```

This fixes that by removing the unused variable `y2` and the assignment to that value.